### PR TITLE
Add meal plan prompt retrieval from PromptLayer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/.gradle
+/build
+/*.iml
+/out

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,7 +28,7 @@ extra["springAiVersion"] = "1.0.0"
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-data-jpa")
 	implementation("org.springframework.boot:spring-boot-starter-web")
-	//implementation("org.springframework.ai:spring-ai-starter-model-anthropic")
+        implementation("org.springframework.ai:spring-ai-starter-model-anthropic")
 	implementation("org.liquibase:liquibase-core")
 	compileOnly("org.projectlombok:lombok")
 	runtimeOnly("org.postgresql:postgresql")

--- a/src/main/java/app/healthy/diet/config/AppConfig.java
+++ b/src/main/java/app/healthy/diet/config/AppConfig.java
@@ -1,0 +1,29 @@
+package app.healthy.diet.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.anthropic.AnthropicChatModel;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+
+@Configuration
+public class AppConfig {
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper();
+    }
+
+
+    @Bean
+    public ChatClient chatClient(AnthropicChatModel anthropicChatModel) {
+        return ChatClient.create(anthropicChatModel);
+    }
+
+    @Bean
+    public RestTemplate restTemplate(RestTemplateBuilder builder) {
+        return builder.build();
+    }
+}

--- a/src/main/java/app/healthy/diet/controller/MealPlanController.java
+++ b/src/main/java/app/healthy/diet/controller/MealPlanController.java
@@ -1,0 +1,24 @@
+package app.healthy.diet.controller;
+
+import app.healthy.diet.model.MealPlan;
+import app.healthy.diet.service.MealPlanService;
+import lombok.RequiredArgsConstructor;
+import java.io.IOException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/meal-plans")
+@RequiredArgsConstructor
+public class MealPlanController {
+
+    private final MealPlanService mealPlanService;
+
+    @GetMapping("/current")
+    public ResponseEntity<MealPlan> getCurrent() throws IOException {
+        MealPlan plan = mealPlanService.getCurrentMealPlan();
+        return ResponseEntity.ok(plan);
+    }
+}

--- a/src/main/java/app/healthy/diet/model/Ingredient.java
+++ b/src/main/java/app/healthy/diet/model/Ingredient.java
@@ -1,0 +1,14 @@
+package app.healthy.diet.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class Ingredient {
+    private String name;
+    private String quantity;
+    private String unit;
+}

--- a/src/main/java/app/healthy/diet/model/Meal.java
+++ b/src/main/java/app/healthy/diet/model/Meal.java
@@ -1,0 +1,22 @@
+package app.healthy.diet.model;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class Meal {
+    private long id;
+    private String name;
+    private MealType mealType;
+    private String description;
+    private String healthBenefits;
+    private int cookingTime;
+    private boolean isLeftover;
+    private List<Ingredient> ingredients;
+    private String recipe;
+}

--- a/src/main/java/app/healthy/diet/model/MealPlan.java
+++ b/src/main/java/app/healthy/diet/model/MealPlan.java
@@ -1,0 +1,19 @@
+package app.healthy.diet.model;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class MealPlan {
+    private long id;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private List<Meal> meals;
+    private int totalCookingTime;
+}

--- a/src/main/java/app/healthy/diet/model/MealType.java
+++ b/src/main/java/app/healthy/diet/model/MealType.java
@@ -1,0 +1,8 @@
+package app.healthy.diet.model;
+
+public enum MealType {
+    BREAKFAST,
+    LUNCH,
+    DINNER,
+    BITE
+}

--- a/src/main/java/app/healthy/diet/service/AnthropicClient.java
+++ b/src/main/java/app/healthy/diet/service/AnthropicClient.java
@@ -1,0 +1,27 @@
+package app.healthy.diet.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.anthropic.AnthropicChatOptions;
+
+
+@Component
+@RequiredArgsConstructor
+public class AnthropicClient {
+
+    private final ChatClient chatClient;
+
+
+    public String complete(String prompt) {
+        AnthropicChatOptions options = AnthropicChatOptions.builder()
+                .model("claude-4")
+                .maxTokens(1024)
+                .build();
+        return chatClient.prompt()
+                .user(prompt)
+                .options(options)
+                .call()
+                .content();
+    }
+}

--- a/src/main/java/app/healthy/diet/service/MealPlanService.java
+++ b/src/main/java/app/healthy/diet/service/MealPlanService.java
@@ -1,0 +1,42 @@
+package app.healthy.diet.service;
+
+import app.healthy.diet.model.MealPlan;
+import app.healthy.diet.model.Meal;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+import java.time.LocalDate;
+
+@Service
+@RequiredArgsConstructor
+public class MealPlanService {
+    private final AnthropicClient anthropicClient;
+    private final PromptLayerClient promptLayerClient;
+    private final ObjectMapper objectMapper;
+
+    @Value("${promptlayer.meal-plan-id}")
+    private String mealPlanPromptId;
+
+    public MealPlan getCurrentMealPlan() throws IOException {
+        LocalDate start = LocalDate.now();
+        LocalDate end = start.plusDays(2);
+        String prompt = buildPrompt(start, end);
+        String completion = anthropicClient.complete(prompt);
+        MealPlan plan = objectMapper.readValue(completion, MealPlan.class);
+        int total = plan.getMeals().stream().mapToInt(Meal::getCookingTime).sum();
+        plan.setStartDate(start);
+        plan.setEndDate(end);
+        plan.setTotalCookingTime(total);
+        return plan;
+    }
+
+    private String buildPrompt(LocalDate start, LocalDate end) throws IOException {
+        String template = promptLayerClient.getPrompt(mealPlanPromptId);
+        return template.replace("{{startDate}}", start.toString())
+                .replace("{{endDate}}", end.toString());
+    }
+}

--- a/src/main/java/app/healthy/diet/service/PromptLayerClient.java
+++ b/src/main/java/app/healthy/diet/service/PromptLayerClient.java
@@ -1,0 +1,35 @@
+package app.healthy.diet.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class PromptLayerClient {
+
+    private final RestTemplate restTemplate;
+    private final ObjectMapper objectMapper;
+
+    @Value("${promptlayer.api-key}")
+    private String apiKey;
+
+    public String getPrompt(String promptId) throws IOException {
+        String url = "https://api.promptlayer.com/v1/prompts/" + promptId;
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", "Bearer " + apiKey);
+        HttpEntity<Void> request = new HttpEntity<>(headers);
+        ResponseEntity<String> response = restTemplate.exchange(url, HttpMethod.GET, request, String.class);
+        JsonNode json = objectMapper.readTree(response.getBody());
+        return json.path("prompt").asText();
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -6,3 +6,12 @@ spring:
     password: password
   liquibase:
     change-log: classpath:db/changelog/db.changelog-master.yaml
+
+  ai:
+    anthropic:
+      api-key: ${ANTHROPIC_API_KEY:}
+
+promptlayer:
+  api-key: ${PROMPTLAYER_API_KEY:}
+  meal-plan-id: ${MEAL_PLAN_PROMPT_ID:meal-plan}
+


### PR DESCRIPTION
## Summary
- fetch meal plan prompt from PromptLayer API instead of a local resource
- add PromptLayer client and properties
- provide `RestTemplate` bean for HTTP calls

## Testing
- `./gradlew test --no-daemon`
- `./gradlew build -x test --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_688098d6e7f8832e9588c4dfe2c606ce