### PR TITLE
Add meal lookup API endpoint

### DIFF
--- a/src/main/java/app/healthy/diet/advice/GlobalExceptionHandler.java
+++ b/src/main/java/app/healthy/diet/advice/GlobalExceptionHandler.java
@@ -1,0 +1,25 @@
+package app.healthy.diet.advice;
+
+import app.healthy.diet.exception.EntityNotFoundException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.Map;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(EntityNotFoundException.class)
+    public ResponseEntity<Map<String, String>> handleEntityNotFound(EntityNotFoundException ex) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(Map.of("error", ex.getMessage()));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<Map<String, String>> handleGeneral(Exception ex) {
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(Map.of("error", ex.getMessage()));
+    }
+}

--- a/src/main/java/app/healthy/diet/controller/MealController.java
+++ b/src/main/java/app/healthy/diet/controller/MealController.java
@@ -1,0 +1,24 @@
+package app.healthy.diet.controller;
+
+import app.healthy.diet.model.Meal;
+import app.healthy.diet.service.MealService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/meals")
+@RequiredArgsConstructor
+public class MealController {
+
+    private final MealService mealService;
+
+    @GetMapping("/{id}")
+    public ResponseEntity<Meal> getMeal(@PathVariable Long id) {
+        Meal meal = mealService.getMealById(id);
+        return ResponseEntity.ok(meal);
+    }
+}

--- a/src/main/java/app/healthy/diet/exception/EntityNotFoundException.java
+++ b/src/main/java/app/healthy/diet/exception/EntityNotFoundException.java
@@ -1,0 +1,7 @@
+package app.healthy.diet.exception;
+
+public class EntityNotFoundException extends RuntimeException {
+    public EntityNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/app/healthy/diet/repository/MealRepository.java
+++ b/src/main/java/app/healthy/diet/repository/MealRepository.java
@@ -11,5 +11,8 @@ public interface MealRepository extends JpaRepository<Meal, Long> {
     boolean existsByCookDate(LocalDate cookDate);
     @Query("SELECT m FROM Meal m LEFT JOIN FETCH m.ingredients WHERE m.cookDate BETWEEN :start AND :end")
     List<Meal> findWithIngredientsBetween(@Param("start") LocalDate start, @Param("end") LocalDate end);
+
+    @Query("SELECT m FROM Meal m LEFT JOIN FETCH m.ingredients WHERE m.id = :id")
+    java.util.Optional<Meal> findWithIngredientsById(@Param("id") Long id);
 }
 

--- a/src/main/java/app/healthy/diet/service/MealService.java
+++ b/src/main/java/app/healthy/diet/service/MealService.java
@@ -1,0 +1,21 @@
+package app.healthy.diet.service;
+
+import app.healthy.diet.mapper.MealMapper;
+import app.healthy.diet.model.Meal;
+import app.healthy.diet.repository.MealRepository;
+import app.healthy.diet.exception.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MealService {
+    private final MealRepository mealRepository;
+    private final MealMapper mealMapper;
+
+    public Meal getMealById(Long id) {
+        var entity = mealRepository.findWithIngredientsById(id)
+                .orElseThrow(() -> new EntityNotFoundException("Meal not found with id " + id));
+        return mealMapper.toDto(entity);
+    }
+}


### PR DESCRIPTION
## Summary
- implement REST endpoint `GET /api/meals/{id}`
- add `MealService` and repository method for fetching meals with ingredients
- create `EntityNotFoundException` runtime exception
- add global controller advice to translate exceptions

## Testing
- `./gradlew build -x test`
- `./gradlew assemble`

------
https://chatgpt.com/codex/tasks/task_e_68833c7475f4832e8ee8a05ee24e1375