### PR TITLE
Add shopping list generation

### DIFF
--- a/src/main/java/app/healthy/diet/entity/ShoppingItem.java
+++ b/src/main/java/app/healthy/diet/entity/ShoppingItem.java
@@ -1,0 +1,26 @@
+package app.healthy.diet.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+@Table(name = "shopping_items")
+public class ShoppingItem {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String ingredientName;
+    private String quantity;
+    private String unit;
+    private boolean isPurchased;
+    private String estimatedCost;
+    private LocalDate planDate;
+}

--- a/src/main/java/app/healthy/diet/mapper/ShoppingItemMapper.java
+++ b/src/main/java/app/healthy/diet/mapper/ShoppingItemMapper.java
@@ -1,0 +1,14 @@
+package app.healthy.diet.mapper;
+
+import app.healthy.diet.model.ShoppingItem;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring")
+public interface ShoppingItemMapper {
+    ShoppingItem toDto(app.healthy.diet.entity.ShoppingItem entity);
+
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "planDate", ignore = true)
+    app.healthy.diet.entity.ShoppingItem toEntity(ShoppingItem item);
+}

--- a/src/main/java/app/healthy/diet/model/ShoppingItem.java
+++ b/src/main/java/app/healthy/diet/model/ShoppingItem.java
@@ -1,0 +1,17 @@
+package app.healthy.diet.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class ShoppingItem {
+    private long id;
+    private String ingredientName;
+    private String quantity;
+    private String unit;
+    private boolean isPurchased;
+    private String estimatedCost;
+}

--- a/src/main/java/app/healthy/diet/repository/ShoppingItemRepository.java
+++ b/src/main/java/app/healthy/diet/repository/ShoppingItemRepository.java
@@ -1,0 +1,7 @@
+package app.healthy.diet.repository;
+
+import app.healthy.diet.entity.ShoppingItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ShoppingItemRepository extends JpaRepository<ShoppingItem, Long> {
+}

--- a/src/main/java/app/healthy/diet/service/MealPlanService.java
+++ b/src/main/java/app/healthy/diet/service/MealPlanService.java
@@ -5,6 +5,7 @@ import app.healthy.diet.model.MealPlan;
 import app.healthy.diet.model.Meal;
 import app.healthy.diet.repository.MealRepository;
 import app.healthy.diet.mapper.MealMapper;
+import app.healthy.diet.service.ShoppingListService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -22,6 +23,7 @@ public class MealPlanService {
     private final ObjectMapper objectMapper;
     private final MealRepository mealRepository;
     private final MealMapper mealMapper;
+    private final ShoppingListService shoppingListService;
 
     private static final String MEAL_PLAN_PROMPT_TEMPLATE = """
             # Role
@@ -44,6 +46,7 @@ public class MealPlanService {
             
             Don't add ```json``` or any other formatting to the JSON response. Just return the JSON object as is.\n
             """;
+
 
     public MealPlan getCurrentMealPlan() throws IOException {
         LocalDate start = LocalDate.now();
@@ -74,6 +77,8 @@ public class MealPlanService {
 
         mealRepository.saveAll(entities);
 
+        shoppingListService.generateAndSave(start, completion);
+
         return plan;
     }
 
@@ -81,4 +86,5 @@ public class MealPlanService {
     private String buildPrompt(LocalDate start, LocalDate end) {
         return String.format(MEAL_PLAN_PROMPT_TEMPLATE, start, end);
     }
+
 }

--- a/src/main/java/app/healthy/diet/service/ShoppingListService.java
+++ b/src/main/java/app/healthy/diet/service/ShoppingListService.java
@@ -1,0 +1,50 @@
+package app.healthy.diet.service;
+
+import app.healthy.diet.client.AnthropicClient;
+import app.healthy.diet.mapper.ShoppingItemMapper;
+import app.healthy.diet.model.ShoppingItem;
+import app.healthy.diet.repository.ShoppingItemRepository;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.time.LocalDate;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ShoppingListService {
+    private final AnthropicClient anthropicClient;
+    private final ObjectMapper objectMapper;
+    private final ShoppingItemRepository shoppingItemRepository;
+    private final ShoppingItemMapper shoppingItemMapper;
+
+    private static final String SHOPPING_LIST_PROMPT_TEMPLATE = """
+            You are a helpful assistant. Use the provided meals JSON to build a consolidated shopping list.\n
+            # Task\n
+            Combine all ingredients from the meals, merge duplicates and sum the required quantities.\n
+            # Format\n            Return only JSON in the following structure:\n
+            [\n  {\n    \"id\": 0,\n    \"ingredientName\": \"\",\n    \"quantity\": \"\",\n    \"unit\": \"\",\n    \"isPurchased\": false,\n    \"estimatedCost\": \"\"\n  }\n]\n
+            Don't add ```json``` or any other formatting to the JSON response.\n
+            Meals JSON:\n%s\n
+            """;
+
+    public void generateAndSave(LocalDate planDate, String mealsJson) throws IOException {
+        String prompt = String.format(SHOPPING_LIST_PROMPT_TEMPLATE, mealsJson);
+        String completion = anthropicClient.complete(prompt);
+        List<ShoppingItem> items = objectMapper.readValue(
+                completion,
+                new TypeReference<List<ShoppingItem>>() {}
+        );
+        var entities = items.stream()
+                .map(item -> {
+                    var entity = shoppingItemMapper.toEntity(item);
+                    entity.setPlanDate(planDate);
+                    return entity;
+                })
+                .toList();
+        shoppingItemRepository.saveAll(entities);
+    }
+}

--- a/src/main/resources/db/changelog/03-create-shopping-items.sql
+++ b/src/main/resources/db/changelog/03-create-shopping-items.sql
@@ -1,0 +1,9 @@
+CREATE TABLE shopping_items (
+    id SERIAL PRIMARY KEY,
+    ingredient_name VARCHAR(255) NOT NULL,
+    quantity VARCHAR(255),
+    unit VARCHAR(64),
+    is_purchased BOOLEAN NOT NULL,
+    estimated_cost VARCHAR(64),
+    plan_date DATE NOT NULL
+);

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -10,3 +10,9 @@ databaseChangeLog:
       changes:
         - sqlFile:
             path: db/changelog/02-create-meals.sql
+  - changeSet:
+      id: 3
+      author: codex
+      changes:
+        - sqlFile:
+            path: db/changelog/03-create-shopping-items.sql


### PR DESCRIPTION
## Summary
- create ShoppingItem entity, model, repository, and mapper
- add liquibase migration to create `shopping_items` table
- update meal plan service to generate shopping list via LLM and save it
- refactor shopping list logic into a new service

## Testing
- `./gradlew test --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_688343a3282c832ea2c5bbb00a4109f5