### PR TITLE
Implement current shopping list endpoint

### DIFF
--- a/src/main/java/app/healthy/diet/controller/ShoppingListController.java
+++ b/src/main/java/app/healthy/diet/controller/ShoppingListController.java
@@ -1,0 +1,23 @@
+package app.healthy.diet.controller;
+
+import app.healthy.diet.model.ShoppingList;
+import app.healthy.diet.service.ShoppingListService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/shopping-lists")
+@RequiredArgsConstructor
+public class ShoppingListController {
+
+    private final ShoppingListService shoppingListService;
+
+    @GetMapping("/current")
+    public ResponseEntity<ShoppingList> getCurrent() {
+        ShoppingList list = shoppingListService.getCurrentShoppingList();
+        return ResponseEntity.ok(list);
+    }
+}

--- a/src/main/java/app/healthy/diet/model/ShoppingList.java
+++ b/src/main/java/app/healthy/diet/model/ShoppingList.java
@@ -1,0 +1,18 @@
+package app.healthy.diet.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class ShoppingList {
+    private long id;
+    private List<ShoppingItem> items;
+    private double estimatedCost;
+    private LocalDate createdDate;
+}

--- a/src/main/java/app/healthy/diet/repository/ShoppingItemRepository.java
+++ b/src/main/java/app/healthy/diet/repository/ShoppingItemRepository.java
@@ -2,6 +2,11 @@ package app.healthy.diet.repository;
 
 import app.healthy.diet.entity.ShoppingItem;
 import org.springframework.data.jpa.repository.JpaRepository;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
 
 public interface ShoppingItemRepository extends JpaRepository<ShoppingItem, Long> {
+    Optional<ShoppingItem> findFirstByPlanDateLessThanEqualOrderByPlanDateDesc(LocalDate date);
+    List<ShoppingItem> findByPlanDate(LocalDate planDate);
 }


### PR DESCRIPTION
## Summary
- add `ShoppingList` DTO
- extend repository and service to fetch the active shopping list
- expose `/api/shopping-lists/current` endpoint
- simplify total cost calculation

## Testing
- `./gradlew test --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_688349162e40832e97709dd3cac091eb