### PR TITLE
Implement inventory endpoint

### DIFF
--- a/src/main/java/app/healthy/diet/controller/InventoryController.java
+++ b/src/main/java/app/healthy/diet/controller/InventoryController.java
@@ -1,0 +1,37 @@
+package app.healthy.diet.controller;
+
+import app.healthy.diet.model.ShoppingItem;
+import app.healthy.diet.service.InventoryService;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.io.IOException;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/inventory")
+@RequiredArgsConstructor
+public class InventoryController {
+
+    private final InventoryService inventoryService;
+
+    @PostMapping
+    public ResponseEntity<Void> addToInventory(@RequestBody InventoryRequest request) throws IOException {
+        inventoryService.addItems(request.getItems());
+        return ResponseEntity.ok().build();
+    }
+
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    private static class InventoryRequest {
+        private List<ShoppingItem> items;
+    }
+}

--- a/src/main/java/app/healthy/diet/entity/InventoryItem.java
+++ b/src/main/java/app/healthy/diet/entity/InventoryItem.java
@@ -1,0 +1,27 @@
+package app.healthy.diet.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+@Table(name = "inventory")
+public class InventoryItem {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String ingredientName;
+    private String quantity;
+    private String unit;
+    private boolean isPurchased;
+    private String estimatedCost;
+    private LocalDate planDate;
+    private LocalDate expirationDate;
+}

--- a/src/main/java/app/healthy/diet/mapper/InventoryItemMapper.java
+++ b/src/main/java/app/healthy/diet/mapper/InventoryItemMapper.java
@@ -1,0 +1,13 @@
+package app.healthy.diet.mapper;
+
+import app.healthy.diet.model.InventoryItem;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring")
+public interface InventoryItemMapper {
+    InventoryItem toDto(app.healthy.diet.entity.InventoryItem entity);
+
+    @Mapping(target = "id", ignore = true)
+    app.healthy.diet.entity.InventoryItem toEntity(InventoryItem item);
+}

--- a/src/main/java/app/healthy/diet/model/InventoryItem.java
+++ b/src/main/java/app/healthy/diet/model/InventoryItem.java
@@ -1,0 +1,21 @@
+package app.healthy.diet.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class InventoryItem {
+    private long id;
+    private String ingredientName;
+    private String quantity;
+    private String unit;
+    private boolean isPurchased;
+    private String estimatedCost;
+    private LocalDate planDate;
+    private LocalDate expirationDate;
+}

--- a/src/main/java/app/healthy/diet/repository/InventoryItemRepository.java
+++ b/src/main/java/app/healthy/diet/repository/InventoryItemRepository.java
@@ -1,0 +1,7 @@
+package app.healthy.diet.repository;
+
+import app.healthy.diet.entity.InventoryItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface InventoryItemRepository extends JpaRepository<InventoryItem, Long> {
+}

--- a/src/main/java/app/healthy/diet/service/InventoryService.java
+++ b/src/main/java/app/healthy/diet/service/InventoryService.java
@@ -1,0 +1,43 @@
+package app.healthy.diet.service;
+
+import app.healthy.diet.client.AnthropicClient;
+import app.healthy.diet.mapper.InventoryItemMapper;
+import app.healthy.diet.model.InventoryItem;
+import app.healthy.diet.model.ShoppingItem;
+import app.healthy.diet.repository.InventoryItemRepository;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class InventoryService {
+    private final AnthropicClient anthropicClient;
+    private final ObjectMapper objectMapper;
+    private final InventoryItemRepository inventoryRepository;
+    private final InventoryItemMapper inventoryMapper;
+
+    private static final String EXPIRATION_PROMPT_TEMPLATE = """
+            You are a helpful assistant that estimates expiration dates for grocery items assuming ideal storage conditions.\n
+            # Format\n            Return only JSON in the following structure:\n            [\n  {\n    \"id\": 0,\n    \"ingredientName\": \"\",\n    \"quantity\": \"\",\n    \"unit\": \"\",\n    \"isPurchased\": false,\n    \"estimatedCost\": \"\",\n    \"planDate\": \"YYYY-MM-DD\",\n    \"expirationDate\": \"YYYY-MM-DD\"\n  }\n]\n
+            Don't add ```json``` or any other formatting to the JSON response.\n
+            Shopping items JSON:\n%s\n""";
+
+    public void addItems(List<ShoppingItem> items) throws IOException {
+        String itemsJson = objectMapper.writeValueAsString(items);
+        String prompt = String.format(EXPIRATION_PROMPT_TEMPLATE, itemsJson);
+        String completion = anthropicClient.complete(prompt);
+        List<InventoryItem> inventoryItems = objectMapper.readValue(
+                completion,
+                new TypeReference<List<InventoryItem>>() {}
+        );
+        var entities = inventoryItems.stream()
+                .map(inventoryMapper::toEntity)
+                .toList();
+        inventoryRepository.saveAll(entities);
+    }
+}

--- a/src/main/resources/db/changelog/04-create-inventory.sql
+++ b/src/main/resources/db/changelog/04-create-inventory.sql
@@ -1,0 +1,10 @@
+CREATE TABLE inventory (
+    id SERIAL PRIMARY KEY,
+    ingredient_name VARCHAR(255) NOT NULL,
+    quantity VARCHAR(255),
+    unit VARCHAR(64),
+    is_purchased BOOLEAN NOT NULL,
+    estimated_cost VARCHAR(64),
+    plan_date DATE NOT NULL,
+    expiration_date DATE NOT NULL
+);

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -16,3 +16,9 @@ databaseChangeLog:
       changes:
         - sqlFile:
             path: db/changelog/03-create-shopping-items.sql
+  - changeSet:
+      id: 4
+      author: codex
+      changes:
+        - sqlFile:
+            path: db/changelog/04-create-inventory.sql


### PR DESCRIPTION
## Summary
- create InventoryItem entity/model/repository/mapper
- implement InventoryService to move shopping list items into inventory and fetch expiration dates from LLM
- expose `/api/inventory` POST endpoint
- add Liquibase migration to create `inventory` table

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_68834abdce30832ea2205db03efd2f8a