### PR TITLE
Fix cook date assignment for meal plans

### DIFF
--- a/src/main/java/app/healthy/diet/service/MealPlanService.java
+++ b/src/main/java/app/healthy/diet/service/MealPlanService.java
@@ -3,6 +3,7 @@ package app.healthy.diet.service;
 import app.healthy.diet.client.AnthropicClient;
 import app.healthy.diet.model.MealPlan;
 import app.healthy.diet.model.Meal;
+import app.healthy.diet.model.MealType;
 import app.healthy.diet.repository.MealRepository;
 import app.healthy.diet.mapper.MealMapper;
 import app.healthy.diet.service.ShoppingListService;
@@ -15,6 +16,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.io.IOException;
 import java.time.LocalDate;
+import java.util.EnumMap;
+import java.util.Map;
 
 @Slf4j
 @Service
@@ -71,8 +74,12 @@ public class MealPlanService {
         plan.setEndDate(end);
         plan.setTotalCookingTime(total);
 
+        Map<MealType, Integer> mealTypeDayCounts = new EnumMap<>(MealType.class);
+
         for (Meal meal : plan.getMeals()) {
-            meal.setCookDate(start); //todo: fix the date handling
+            int dayOffset = mealTypeDayCounts.getOrDefault(meal.getMealType(), 0);
+            meal.setCookDate(start.plusDays(dayOffset));
+            mealTypeDayCounts.put(meal.getMealType(), dayOffset + 1);
         }
 
         var entities = plan.getMeals().stream()


### PR DESCRIPTION
## Summary
- distribute cook dates across generated meals by meal type
- track per-meal-type offsets to advance the cook date appropriately

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68970caec470832eace2a977064999f2