### PR TITLE
Separate ingredient details from name

### DIFF
--- a/src/main/java/app/healthy/diet/entity/Ingredient.java
+++ b/src/main/java/app/healthy/diet/entity/Ingredient.java
@@ -18,6 +18,7 @@ public class Ingredient {
     private Long id;
 
     private String name;
+    private String details;
     private double grams;
 
     @ManyToOne

--- a/src/main/java/app/healthy/diet/model/Ingredient.java
+++ b/src/main/java/app/healthy/diet/model/Ingredient.java
@@ -9,5 +9,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class Ingredient {
     private String name;
+    private String details;
     private double grams;
 }

--- a/src/main/java/app/healthy/diet/service/MealPlanService.java
+++ b/src/main/java/app/healthy/diet/service/MealPlanService.java
@@ -43,6 +43,7 @@ public class MealPlanService {
             The daily total cooking time for the meal plan should not exceed 90 minutes.\n
             The ingredients may be found in a typical grocery store and should be easy to prepare.\n
             The recipe field in the response should include step-by-step instructions for preparing the meal.\n
+            Ingredient preparation details like "sliced" or "chopped" must be placed in a separate "details" field while the "name" contains only the ingredient itself.\n
 
             The following meals were generated recently and should be excluded from the new plan: %s\n
 
@@ -51,7 +52,7 @@ public class MealPlanService {
             
             # Format
             Return only JSON in the following structure:\n
-            {\n  \"meals\": [\n    {\n      \"id\": 0,\n      \"name\": \"\",\n      \"mealType\": \"BREAKFAST|LUNCH|DINNER|BITE\",\n      \"description\": \"\",\n      \"healthBenefits\": \"\",\n      \"cookingTime\": 0,\n      \"leftover\": false,\n      \"ingredients\": [ { \"name\": \"\", \"grams\": 0 } ],\n      \"recipe\": \"\"\n    }\n  ]\n}\n
+            {\n  \"meals\": [\n    {\n      \"id\": 0,\n      \"name\": \"\",\n      \"mealType\": \"BREAKFAST|LUNCH|DINNER|BITE\",\n      \"description\": \"\",\n      \"healthBenefits\": \"\",\n      \"cookingTime\": 0,\n      \"leftover\": false,\n      \"ingredients\": [ { \"name\": \"\", \"details\": \"\", \"grams\": 0 } ],\n      \"recipe\": \"\"\n    }\n  ]\n}\n
             
             Don't add ```json``` or any other formatting to the JSON response. Just return the JSON object as is.\n
             """;

--- a/src/main/resources/db/changelog/07-add-ingredient-details.sql
+++ b/src/main/resources/db/changelog/07-add-ingredient-details.sql
@@ -1,0 +1,1 @@
+ALTER TABLE ingredients ADD COLUMN details TEXT;

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -34,3 +34,9 @@ databaseChangeLog:
       changes:
         - sqlFile:
             path: db/changelog/06-add-cooked-flag.sql
+  - changeSet:
+      id: 7
+      author: codex
+      changes:
+        - sqlFile:
+            path: db/changelog/07-add-ingredient-details.sql


### PR DESCRIPTION
## Summary
- add `details` field to ingredient entity and DTO
- update meal plan generation prompt to place prep details in `details` and keep clean names
- add Liquibase migration for ingredient `details` column

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_689724555990832eb5a3b5c90d6cf845